### PR TITLE
Require a recent version of networkx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 requirements = [
     'decorator',
     'numpy',
-    'networkx',
+    'networkx>=2.4',
     'pandas',
     'realalg',
     'snappy',


### PR DESCRIPTION
At sage-flatsurf we found that flipper emits lots of warning when importing older versions of networkx with a recent Python. I am not sure what actually the minimum version of networkx that flipper needs is, but I guess it certainly needs a >=2.2 version. If we could require 2.4 that would be great as that could simplify our testing a bit.