### PR TITLE
Triangulation.from_string: handle isosigs with more than 62 triangles

### DIFF
--- a/flipper/kernel/triangulation.py
+++ b/flipper/kernel/triangulation.py
@@ -443,8 +443,8 @@ class Triangulation:
             start = 1
         else:
             num_chars = values[1]  # This must be > 1.
-            num_tri = debase(values[1:num_chars])
-            start = 1 + num_chars
+            num_tri = debase(values[2:num_chars+2])
+            start = 2 + num_chars
         
         if num_chars == 0:
             raise ValueError('Signature must specify a character length > 0.')


### PR DESCRIPTION
Currently
```
F = flipper.create_triangulation([(~134, ~106, ~27), (~133, ~105, ~26), (~132, ~104, ~25), (~131, ~103, ~24), (~130, ~102, ~23), (~129, ~22, 124), (~128, ~21, 123), (~127, ~20, 122), (~126, ~19, 121), (~125, ~18, 120), (~124, ~17, 119), (~123, ~16, 118), (~122, ~15, 117), (~121, ~14, 116), (~120, ~13, 115), (~119, ~12, 114), (~118, ~11, 113), (~117, ~10, 112), (~116, ~9, 111), (~115, ~8, 110), (~114, ~7, 109), (~113, ~6, 108), (~112, ~5, 107), (~111, ~4, 106), (~110, ~3, 105), (~109, ~2, 104), (~108, ~1, 103), (~107, ~0, 102), (~101, 83, 22), (~100, 82, 21), (~99, 81, 20), (~98, 80, 19), (~97, 79, 18), (~96, 78, 17), (~95, 77, 16), (~94, 76, 15), (~93, 75, 14), (~92, 74, 13), (~91, 73, 12), (~90, 72, 11), (~89, 71, 10), (~88, 70, 9), (~87, 69, 8), (~86, 68, 7), (~85, 67, 6), (~84, 61, 92), (~83, 60, 91), (~82, 59, 90), (~81, 58, 89), (~80, 57, 88), (~79, 56, 87), (~78, 36, 45), (~77, 35, 44), (~76, 34, 43), (~75, 33, 42), (~74, 32, 41), (~73, 31, 40), (~72, 30, 39), (~71, 29, 38), (~70, 55, 27), (~69, 54, 26), (~68, 53, 25), (~67, 52, 24), (~66, ~62, ~54), (~65, ~56, 37), (~64, 86, ~45), (~63, 85, ~44), (~61, ~51, 66), (~60, ~50, 65), (~59, ~49, 64), (~58, ~48, 63), (~57, ~47, 62), (~55, 28, ~52), (~53, ~37, ~46), (~43, 51, 5), (~42, 50, 4), (~41, 49, 3), (~40, 48, 2), (~39, 47, 1), (~38, 46, 0), (~36, 101, 134), (~35, 100, 133), (~34, 99, 132), (~33, 98, 131), (~32, 97, 130), (~31, 96, 129), (~30, 95, 128), (~29, 94, 127), (~28, 93, 126), (23, 84, 125)])
isosig = F.iso_sig()
print(isosig)
I = flipper.triangulation_from_iso_sig(isosig)
```
results in
```
-cAbvvvvvvvvvvvvvLzvQwvzPLvLMvLwAwzQMQPQPvMzzzQLQMaLaFaSaUaDaWaVaHaTa5aQaPa-a+aebebgbgb1akbhb-a7a6a9a8afbmbmbbbdbkbdbjbnbpbqbsbsbxbubybzbybzbdacdebedceeffedaedafdebcffbaeaccecbccdbcecdaef
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[...]/site-packages/flipper/kernel/triangulation.py", line 462, in from_string
    raise ValueError('Signature must specify permutations for each triangle.')
ValueError: Signature must specify permutations for each triangle.
```
Regina confirms that `-cAbvvvvv...` is a valid isosig for a surface.  With this patch, there is no error and moreover:
```
>>> I.iso_sig() == isosig and F.is_isometric_to(I)
True
```
